### PR TITLE
Fixed comparision of file and folder identifiers

### DIFF
--- a/Classes/Driver/StorageDriver.php
+++ b/Classes/Driver/StorageDriver.php
@@ -275,7 +275,7 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
      */
     public function isWithin($folderIdentifier, $identifier)
     {
-        return GeneralUtility::isFirstPartOfStr($identifier, $folderIdentifier);
+        return GeneralUtility::isFirstPartOfStr('/' . ltrim($identifier, '/'), $folderIdentifier);
     }
 
     /**


### PR DESCRIPTION
Uploaded files to google cloud creates file identifiers without leading slash. An editor do not get permission on own uploaded files, because the comparision of file identifier and root folder of the file mount fails.

This fix add a leading slash to get a correct comparision.