### PR TITLE
Update to PHP8 and google/cloud-storage 1.26.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   ],
   "type": "typo3-cms-extension",
   "require": {
-    "php": "^7.1",
+    "php": ">=7.1 <8.1",
     "typo3/cms-core": ">=10.4 <11.9.99",
     "google/cloud-storage": "^v1.23"
   },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require": {
     "php": ">=7.1 <8.1",
     "typo3/cms-core": ">=10.4 <11.9.99",
-    "google/cloud-storage": "^v1.23"
+    "google/cloud-storage": ">=v1.23 <1.27"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Hi All,

we have tested that the driver is working with PHP 8.0.8 and Typo3 11.5. 

Regards,
Harry